### PR TITLE
Easier way to create a new branch

### DIFF
--- a/branch.config.js
+++ b/branch.config.js
@@ -1,0 +1,79 @@
+import { execSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+// Helper to handle the __dirname with ES modules
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Get the branch name passed from the npm script
+const branchName = process.argv[2];
+
+if (!branchName) {
+  console.error("Error: No branch name provided.");
+  process.exit(1);
+}
+
+// Convert the branch name to lowercase for certain cases
+const lowerCaseBranchName = branchName.toLowerCase();
+
+// Capitalize the first letter for certain cases (Branchname)
+const capitalizedBranchName = branchName.charAt(0).toUpperCase() + branchName.slice(1).toLowerCase();
+
+try {
+  // Commit any uncommitted changes in the current branch (optional but recommended)
+  execSync('git add .');
+  execSync('git commit -m "Save work before switching branches" || true', { stdio: 'inherit' });
+
+  // Create the new branch (lowercase) and switch to it
+  execSync(`git checkout -b ${lowerCaseBranchName}`, { stdio: 'inherit' });
+  console.log(`Branch '${lowerCaseBranchName}' created and switched to successfully.`);
+
+  // Now create the folder structure and files in the new branch
+  const newProjectPath = path.join(__dirname, 'src', 'projectes', lowerCaseBranchName);
+
+  fs.mkdirSync(newProjectPath, { recursive: true });
+  fs.mkdirSync(path.join(newProjectPath, 'data'));
+
+  // Create index.md using capitalizedBranchName for readability in the file
+  fs.writeFileSync(path.join(newProjectPath, 'index.md'), `# ${capitalizedBranchName}\n\nProject page content here.`);
+
+  // Create dades.json.js with lowercase for data file
+  fs.writeFileSync(path.join(newProjectPath, 'data', 'dades.json.js'), `// Data for ${capitalizedBranchName}`);
+
+  console.log(`Created folder and files for '${lowerCaseBranchName}' in branch '${lowerCaseBranchName}'.`);
+
+  // Update observablehq.config.js in the new branch
+  const configFilePath = path.join(__dirname, 'observablehq.config.js');
+  let configFileContent = fs.readFileSync(configFilePath, 'utf8');
+
+  const newPageEntry = `{name: "${capitalizedBranchName}", path: "/projectes/${lowerCaseBranchName}/"}`;
+  const projectesSectionRegex = /({\s*name:\s*"Projectes",\s*path:\s*".*?",\s*open:\s*false,\s*pages:\s*\[\s*)([^]*?)(\s*]\s*})/;
+
+  const match = configFileContent.match(projectesSectionRegex);
+
+  if (match) {
+    const existingPages = match[2].trim();
+    const lastPageEntry = existingPages.split('\n').pop().trim();
+    const updatedPages =
+      lastPageEntry.endsWith(',')
+        ? existingPages + `\n        ${newPageEntry},`
+        : existingPages + `,\n        ${newPageEntry}`;
+
+    configFileContent =
+      configFileContent.slice(0, match.index + match[1].length) +
+      updatedPages +
+      configFileContent.slice(match.index + match[0].length);
+
+    fs.writeFileSync(configFilePath, configFileContent, 'utf8');
+    console.log(`Updated observablehq.config.js with new branch '${capitalizedBranchName}'.`);
+  } else {
+    console.error("Error: Unable to find 'Projectes' section in config.");
+    process.exit(1);
+  }
+
+} catch (error) {
+  console.error(`Error: ${error.message}`);
+  process.exit(1);
+}

--- a/branch.config.js
+++ b/branch.config.js
@@ -56,15 +56,23 @@ try {
   if (match) {
     const existingPages = match[2].trim();
     const lastPageEntry = existingPages.split('\n').pop().trim();
-    const updatedPages =
-      lastPageEntry.endsWith(',')
-        ? existingPages + `\n        ${newPageEntry},`
-        : existingPages + `,\n        ${newPageEntry}`;
+
+    // Check if last entry has a comma, and add one if necessary
+    const pagesWithComma = lastPageEntry.endsWith(',')
+      ? existingPages
+      : existingPages + ',';
+
+    const updatedPages = pagesWithComma + `\n        ${newPageEntry}`;
 
     configFileContent =
       configFileContent.slice(0, match.index + match[1].length) +
       updatedPages +
       configFileContent.slice(match.index + match[0].length);
+
+    // Ensure correct closing brackets for "Projectes" and "pages"
+    if (!configFileContent.endsWith('  ],')) {
+      configFileContent += '\n  ],';
+    }
 
     fs.writeFileSync(configFilePath, configFileContent, 'utf8');
     console.log(`Updated observablehq.config.js with new branch '${capitalizedBranchName}'.`);

--- a/branch.config.js
+++ b/branch.config.js
@@ -71,7 +71,9 @@ try {
 
     // Ensure correct closing brackets for "Projectes" and "pages"
     if (!configFileContent.endsWith('  ],')) {
-      configFileContent += '\n  ],';
+      configFileContent += `]
+    }
+  ],`;
     }
 
     fs.writeFileSync(configFilePath, configFileContent, 'utf8');

--- a/branch.config.js
+++ b/branch.config.js
@@ -46,37 +46,21 @@ try {
 
   // Update observablehq.config.js in the new branch
   const configFilePath = path.join(__dirname, 'observablehq.config.js');
-  let configFileContent = fs.readFileSync(configFilePath, 'utf8');
+  const config = require(configFilePath); // Load the config as a JS object
 
-  const newPageEntry = `{name: "${capitalizedBranchName}", path: "/projectes/${lowerCaseBranchName}/"}`;
-  const projectesSectionRegex = /({\s*name:\s*"Projectes",\s*path:\s*".*?",\s*open:\s*false,\s*pages:\s*\[\s*)([^]*?)(\s*]\s*})/;
+  // Find the "Projectes" section and append the new page entry
+  const projectesSection = config.pages.find(section => section.name === "Projectes");
+  
+  if (projectesSection) {
+    // Add the new entry
+    projectesSection.pages.push({
+      name: capitalizedBranchName,
+      path: `/projectes/${lowerCaseBranchName}/`
+    });
 
-  const match = configFileContent.match(projectesSectionRegex);
-
-  if (match) {
-    const existingPages = match[2].trim();
-    const lastPageEntry = existingPages.split('\n').pop().trim();
-
-    // Check if last entry has a comma, and add one if necessary
-    const pagesWithComma = lastPageEntry.endsWith(',')
-      ? existingPages
-      : existingPages + ',';
-
-    const updatedPages = pagesWithComma + `\n        ${newPageEntry}`;
-
-    configFileContent =
-      configFileContent.slice(0, match.index + match[1].length) +
-      updatedPages +
-      configFileContent.slice(match.index + match[0].length);
-
-    // Ensure correct closing brackets for "Projectes" and "pages"
-    if (!configFileContent.endsWith('  ],')) {
-      configFileContent += `]
-    }
-  ],`;
-    }
-
-    fs.writeFileSync(configFilePath, configFileContent, 'utf8');
+    // Write the updated object back to observablehq.config.js
+    const updatedConfig = `export default ${JSON.stringify(config, null, 2)};`;
+    fs.writeFileSync(configFilePath, updatedConfig, 'utf8');
     console.log(`Updated observablehq.config.js with new branch '${capitalizedBranchName}'.`);
   } else {
     console.error("Error: Unable to find 'Projectes' section in config.");

--- a/branch.config.js
+++ b/branch.config.js
@@ -46,7 +46,9 @@ try {
 
   // Update observablehq.config.js in the new branch
   const configFilePath = path.join(__dirname, 'observablehq.config.js');
-  const config = require(configFilePath); // Load the config as a JS object
+  const configContent = fs.readFileSync(configFilePath, 'utf8'); // Read the config file as a string
+  const configModule = await import(configFilePath); // Dynamically import the config file as an ES module
+  const config = configModule.default; // Access the default export of the module
 
   // Find the "Projectes" section and append the new page entry
   const projectesSection = config.pages.find(section => section.name === "Projectes");

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "build": "rimraf dist && observable build",
     "dev": "observable preview",
     "deploy": "observable deploy",
-    "observable": "observable"
+    "observable": "observable",
+    "newbranch": "node branch.config.js"
   },
   "dependencies": {
     "@observablehq/framework": "^1.7.0",


### PR DESCRIPTION
The idea is to make it easier for users to start a new project. To start working on their own projects, they need to:
- Create a new local branch
- Create a new project structure, data folder, an index.md ...
- Update the observablehq.config.js file to have the project visible in the left menu. 

Now, if you go `npm run newbranch aire` (`aire` would be the name of your project), it will do all this.

We will need to update the docs to explain this as well.
- [ ] Add the `npm run newbranch ELTEUPROJECTE` step to the [docs](https://catalunya-en-dades.fndvit.org/docs/pages/preguntes-tecniques.html).
- [ ] Maybe add that they should go to `localhost:3000/projectes/ELTEUPROJECTE/` or navigate to it using the left menu in any of the inside pages?