### PR TITLE
Plot Catalunya Map with 65+ Population Percentage Using Shapefile Conversion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "hasInstallScript": true,
       "dependencies": {
         "@observablehq/framework": "^1.7.0",
         "chroma-js": "^2.4.2",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "build": "rimraf dist && observable build",
     "dev": "observable preview",
     "deploy": "observable deploy",
-    "observable": "observable"
+    "observable": "observable",
+    "install": "pip install -r requirements.txt"
   },
   "dependencies": {
     "@observablehq/framework": "^1.7.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+geopandas

--- a/src/projectes/gent-gran/data/comarques_catalunya.json.py
+++ b/src/projectes/gent-gran/data/comarques_catalunya.json.py
@@ -1,0 +1,25 @@
+from io import BytesIO
+from zipfile import ZipFile
+from urllib.request import urlopen
+import sys
+import geopandas as gpd
+
+catalunya_zip_url = 'https://datacloud.icgc.cat/datacloud/divisions-administratives/shp/divisions-administratives-v2r1-20240705.zip'
+file_response_by_request = urlopen(catalunya_zip_url)
+zip_file_memory = ZipFile(BytesIO(file_response_by_request.read()))
+
+# The ZIP file contains multiple shapefiles at different levels or scales. A scale map of 1:1,000,000 is sufficient.
+files_shape_selected = [file_name for file_name in zip_file_memory.namelist() if 'comarques-1000000' in file_name]
+for level_map_file in files_shape_selected:
+    with zip_file_memory.open(level_map_file) as file:
+        with open(f'/tmp/{level_map_file}', 'wb') as f:
+            f.write(file.read())
+
+comarques_df = gpd.read_file(
+    f'/tmp/{next(file_name for file_name in files_shape_selected if file_name.endswith('.shp'))}')
+sys.stderr.writelines([str(len(comarques_df.geometry))])
+
+# Change to CRS 4326 - d3 standard
+comarques_df = comarques_df.to_crs(epsg=4326)
+sys.stderr.writelines([str(len(comarques_df.geometry))])
+print(comarques_df.to_json())

--- a/src/projectes/gent-gran/data/population.json.py
+++ b/src/projectes/gent-gran/data/population.json.py
@@ -1,0 +1,44 @@
+import pandas as pd
+import urllib.request, json
+import sys
+
+with urllib.request.urlopen("https://api.idescat.cat/taules/v2/censph/540/19948/com/data") as url:
+    data = json.load(url)
+
+# The API endpoint returns a sequential, single array of data.
+# To access the required values, the array should be mapped using the indexes provided in the metadata.
+dimension = data['dimension']
+sizes = data['size']
+dimension_year = sizes[1] * sizes[2] * sizes[3]
+dimension_community = sizes[2] * sizes[3]
+dimension_sex = sizes[3]
+index_sex_total = list(dimension['SEX']['category']['label'].keys()).index('TOTAL')
+index_age_65 = list(dimension['AGE']['category']['label'].keys()).index('Y_GE065')
+index_age_total = list(dimension['AGE']['category']['label'].keys()).index('TOTAL')
+
+data_values = data['value']
+
+year_values = []
+community_name_population_over_65 = []
+population_over_65 = []
+population = []
+
+for year_index, year in enumerate(dimension['YEAR']['category']['label'].items()):
+    for community_index, community in enumerate(dimension['COM']['category']['label'].items()):
+        if community[0] != 'TOTAL':
+            year_values.append(int(year[1]))
+            community_name_population_over_65.append(str(community[1]))
+            population_over_65.append(data_values[year_index * dimension_year +
+                                                  community_index * dimension_community +
+                                                  index_sex_total * dimension_sex +
+                                                  index_age_65])
+            population.append(data_values[year_index * dimension_year +
+                                          community_index * dimension_community +
+                                          index_sex_total * dimension_sex +
+                                          index_age_total])
+
+population_df = pd.DataFrame({'year': year_values,
+                              'nom_comarca': community_name_population_over_65,
+                              'population_over_65': population_over_65,
+                              'population': population})
+population_df.to_json(sys.stdout, orient='records')

--- a/src/projectes/gent-gran/index.md
+++ b/src/projectes/gent-gran/index.md
@@ -1,6 +1,87 @@
 ```js
-
 const population = FileAttachment("data/population.json").json();
 const comarques_catalunya = FileAttachment("data/comarques_catalunya.json").json();
+````
+
+```js
+const nom_comarques = comarques_catalunya.features.map(d => d.properties.NOMCOMAR);
 ```
+
+```js
+function set(input, value) {
+    input.value = value;
+    input.dispatchEvent(new Event("input", {bubbles: true}));
+}
+```
+
+```js
+const latest_year = Math.max.apply(Math, population.map(row => row.year));
+const comarques_latest_population = Object.fromEntries(
+    population
+        .filter(row => row.year === latest_year)
+        .map(row => Array(row.nom_comarca, Math.round(row.population_over_65 * 1000.0 / row.population) / 10.0)))
+```
+
+```js
+const nom_comarca_input = Inputs.select(
+    comarques_catalunya.features.map((d) => d.properties.NOMCOMAR),
+    {
+        sort: true,
+        unique: true,
+        label: "Nom Comarca",
+        value: "Alt Camp"
+    }
+);
+const nom_comarca = Generators.input(nom_comarca_input);
+```
+
+```js
+
+const plot_catalunya_map_aged_65 = (width) => {
+    return Plot.plot({
+        projection: {
+            type: "conic-conformal",
+            domain: comarques_catalunya
+        },
+        color: {
+            type: "threshold",
+            scheme: "buylrd",
+            legend: true,
+            pivot: 17.96,
+            n: 10,
+            unknown: "black",
+            domain: [14, 16, 18, 20, 22, 24, 26, 30],
+            label: "Població de 65 anys i més (%)",
+        },
+        width: width,
+        marks: [
+            Plot.geo(comarques_catalunya, {
+                fill: (d) => comarques_latest_population[d.properties.NOMCOMAR],
+                title: d => d.properties.NOMCOMAR,
+                strokeOpacity: 1.0,
+                strokeWidth: 1,
+                stroke: "black",
+                tip: true
+            })
+
+
+        ]
+    });
+};
+
+```
+
 # Gent Gran
+
+<div class="grid grid-cols-4">
+    <div class="card grid-colspan-2">
+        <h2>Població de 65 anys i més (%)</h2>
+El següent mapa de Catalunya mostra cada comarca amb aquest indicador analitzat per a l'any més recent.
+El valor central representa la mitjana d'Espanya, que és del 21% d'aquest indicador.
+Com a referència addicional, la mediana global se situa en el 10%.
+        <figure class="grafic" style="max-width: none;">
+            ${resize((width) => plot_catalunya_map_aged_65(width))}
+        </figure>
+    </div>
+    
+</div>

--- a/src/projectes/gent-gran/index.md
+++ b/src/projectes/gent-gran/index.md
@@ -1,0 +1,6 @@
+```js
+
+const population = FileAttachment("data/population.json").json();
+const comarques_catalunya = FileAttachment("data/comarques_catalunya.json").json();
+```
+# Gent Gran


### PR DESCRIPTION
This PR adds a visualization of the percentage of the population aged 65 and older for each comarca in Catalunya.

Key Changes:

-    Uses a shapefile instead of the provided GeoJSON (which follows RFC 7946) due to compatibility issues with D3.js.
    -    [Administrative Boundaries - ICGC](https://www.icgc.cat/en/Geoinformation-and-Maps/Data-and-products/Cartographic-geoinformation/Administrative-boundaries)
    -    [D3 Geo Documentation](https://d3js.org/d3-geo)
-    Loads population data by broad age groups.
    -    [IDESCAT Open Data - Census](https://www.idescat.cat/dades/obertes/censph?lang=en)
-    Calculates the percentage of the population aged 65+ for each comarca using the most recent available data.
-    Displays the indicator on a map.