### PR TITLE
Sidemenu and route fix

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -79,7 +79,7 @@ iframe {
   <h1>Catalunya 👀 en dades</h1>
   <h2>És una iniciativa per <b>reimaginar la visualització de dades obertes de l'administració catalana</b> fent servir l'<em>Observable Framework</em>. La participació és oberta a tothom que estigui aprenent 🧑‍💻📓📈🔍 ciència de dades, comunicació, disseny o visualització de dades, amb 🏅 premis mensuals (i un 🏆 gran premi final) a les millors col·laboracions.</h2>
 
-  <a href="/docs/pages/participa.html">Col·labora<span style="display: inline-block; margin-left: 0.25rem;">→</span></a>
+  <a href="/docs/participa">Col·labora<span style="display: inline-block; margin-left: 0.25rem;">→</span></a>
 </div>
 
 <iframe id="iframe" scrolling="no" src="https://sequera.fndvit.org/"></iframe>

--- a/src/projectes/dashboard.css
+++ b/src/projectes/dashboard.css
@@ -118,3 +118,13 @@ main h2 {
   width: 100%;
   left: 0;
 }
+
+#observablehq-header {
+  left: calc( var(--observablehq-inset-left) + 2rem);
+  right: calc(var(--observablehq-inset-right) + 2rem);
+}
+
+body {
+  margin: 0;
+  max-width: none;
+}

--- a/src/projectes/dashboard.css
+++ b/src/projectes/dashboard.css
@@ -111,6 +111,7 @@ main h2 {
 #observablehq-sidebar {
   padding: 0 8px 16px 8px;
   visibility: hidden;
+  width: 272px;
 }
 
 #observablehq-search-results {

--- a/src/style.css
+++ b/src/style.css
@@ -126,6 +126,7 @@ pre {
 #observablehq-sidebar {
   padding: 0 8px 16px 8px;
   visibility: hidden;
+  width: 272px;
 }
 
 #observablehq-search-results {

--- a/src/style.css
+++ b/src/style.css
@@ -133,3 +133,13 @@ pre {
   width: 100%;
   left: 0;
 }
+
+#observablehq-header {
+  left: calc( var(--observablehq-inset-left) + 2rem);
+  right: calc(var(--observablehq-inset-right) + 2rem);
+}
+
+body {
+  margin: 0;
+  max-width: none;
+}


### PR DESCRIPTION
## PR Summary  

This PR addresses two issues:  

- The menu now has a fixed width of **272px**, matching the width used in the previous version.  
- The routing for the **"Collabora"** text on the landing page has been updated to point to `/doc/participa`.  
